### PR TITLE
986064: Resolve Failures in GitHub Repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 > This sample explains the way to open the [EJ2 JavaScript Schedule](https://www.syncfusion.com/javascript-ui-controls/js-scheduler) editor window in single click. Refer to the below KB for more details.
 
 https://www.syncfusion.com/kb/10608/how-to-open-editor-window-in-single-click
+
+In this example, the Syncfusion JavaScript Scheduler is configured to open the event editor window with a single click. The popupOpen event is used to intercept the default quick popup behavior. When the user clicks on a work cell or an existing event, the popup is canceled using args.cancel = true, and the editor window is manually triggered using openEditor. This allows for a more streamlined and direct editing experience. The editor opens in either "Add" or "Save" mode depending on the target element clicked.
+
+This approach enhances usability by reducing the number of interactions needed to manage events and provides a faster way to access full event details for editing. It is especially useful in applications where quick scheduling and minimal clicks are preferred for better productivity.


### PR DESCRIPTION
### Bug description
[986064](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/986064/): Resolve Failures in GitHub Repositories

### Root cause,
The repository readme must have a minimum length of 1000 characters, whereas the current readme length is less than 1000 characters

### Reason for not identifying earlier
Find how it was missed in our earlier testing and development by analysing the below checklist. This will help prevent similar mistakes in the future. 

 - [x] Guidelines/documents are not followed

    - Specification document

 - [ ] Guidelines/documents are not given

    - Common guidelines / Core team guideline
    - Specification document
    - Requirement document


### Reason:

I have resolved by add the content in Readme description.

### Output screenshots:

NA

### Action taken:

I have resolved by add the content in Readme description.

### Related areas:

NA

### Is it a breaking issue?

No

### Solution description

I have resolved by add the content in Readme description.

### Areas affected and ensured

NA

### Additional checklist
This may vary for different teams or products. Check with your scrum masters.

  - Did you run the automation against your fix? Yes
  - Is there any API name change? No
  - Is there any existing behavior change of other features due to this code change? No
  - Does your new code introduce new warnings or binding errors? No
  - Does your code pass all FxCop and StyleCop rules? NA
  - Did you record this case in the unit test or UI test? NA
  - 